### PR TITLE
Code quality fix - Primitives should not be boxed just for "String" conversion.

### DIFF
--- a/src/main/java/io/parallec/core/actor/ExecutionManager.java
+++ b/src/main/java/io/parallec/core/actor/ExecutionManager.java
@@ -338,9 +338,7 @@ public class ExecutionManager extends UntypedActor {
                             + " / "
                             + requestCount
                             + " after "
-                            + new Double(
-                                    (prepareRequestTime - startTime) / 1000.0)
-                                    .toString() + " secs"
+                            + Double.toString((prepareRequestTime - startTime) / 1000.0) + " secs"
                             + ":  (NOT SEND YET) " + targetHost + " at "
                             + prepareRequestTimeStr);
 
@@ -456,8 +454,7 @@ public class ExecutionManager extends UntypedActor {
                         / (double) (requestCount) * 100.0;
                 String responseReceiveTimeStr = PcDateUtils
                         .getDateTimeStrStandard(new Date(responseReceiveTime));
-                String secondElapsedStr = new Double(
-                        (responseReceiveTime - startTime) / 1000.0).toString();
+                String secondElapsedStr = Double.toString((responseReceiveTime - startTime) / 1000.0);
                 
                 // log the first/ last 5 percent; then sample the middle
                 if(requestCount < ParallecGlobalConfig.logAllResponseIfTotalLessThan

--- a/src/main/java/io/parallec/core/commander/workflow/VarReplacementProvider.java
+++ b/src/main/java/io/parallec/core/commander/workflow/VarReplacementProvider.java
@@ -150,7 +150,7 @@ public class VarReplacementProvider {
                             + replaceVarKey, replaceVarValue);
             nodeReqResponse.getRequestParameters().put(
                     PcConstants.NODE_REQUEST_WILL_EXECUTE,
-                    new Boolean(true).toString());
+                    Boolean.toString(true));
 
         }// end for loop
 
@@ -216,7 +216,7 @@ public class VarReplacementProvider {
 
                     nodeReqResponse.getRequestParameters().put(
                             PcConstants.NODE_REQUEST_WILL_EXECUTE,
-                            new Boolean(false).toString());
+                            Boolean.toString(false));
 
                     /**
                      * 20130828: make it generic to check NULL KEY/VALUE
@@ -239,11 +239,11 @@ public class VarReplacementProvider {
                             .contains(PcConstants.NA)) {
                         nodeReqResponse.getRequestParameters().put(
                                 PcConstants.NODE_REQUEST_WILL_EXECUTE,
-                                new Boolean(false).toString());
+                                Boolean.toString(false));
                     } else {
                         nodeReqResponse.getRequestParameters().put(
                                 PcConstants.NODE_REQUEST_WILL_EXECUTE,
-                                new Boolean(true).toString());
+                                Boolean.toString(true));
                     }
 
                 }

--- a/src/main/java/io/parallec/core/commander/workflow/ssh/SshProvider.java
+++ b/src/main/java/io/parallec/core/commander/workflow/ssh/SshProvider.java
@@ -214,7 +214,7 @@ public class SshProvider {
                     // exit 0 is good
                     int exitStatus = channel.getExitStatus();
                     sshResponse.setStatusCodeInt(exitStatus);
-                    sshResponse.setStatusCode("" + exitStatus);
+                    sshResponse.setStatusCode(Integer.toString(exitStatus));
                     break;
                 }
 

--- a/src/main/java/io/parallec/core/monitor/MonitorProvider.java
+++ b/src/main/java/io/parallec/core/monitor/MonitorProvider.java
@@ -119,7 +119,7 @@ public class MonitorProvider {
             ThreadInfo threadInfo = threadMxBean.getThreadInfo(tId);
             if(threadInfo==null) continue;
             threadUsage.threadData.put(
-                    Long.valueOf(tId).toString(),
+                    Long.toString(tId),
                     new ThreadData(threadInfo.getThreadName(), threadInfo
                             .getThreadState().name(), threadMxBean
                             .getThreadCpuTime(tId)));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2131- Primitives should not be boxed just for "String" conversion.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131

Please let me know if you have any questions.

Faisal Hameed