### PR TITLE
Param setup bug in ParallelClient

### DIFF
--- a/src/main/java/io/parallec/core/ParallelClient.java
+++ b/src/main/java/io/parallec/core/ParallelClient.java
@@ -12,6 +12,7 @@ limitations under the License.
  */
 package io.parallec.core;
 
+import com.ning.http.client.AsyncHttpClient;
 import io.parallec.core.actor.ActorConfig;
 import io.parallec.core.monitor.MonitorProvider;
 import io.parallec.core.resources.HttpClientStore;
@@ -19,13 +20,10 @@ import io.parallec.core.resources.HttpClientType;
 import io.parallec.core.resources.HttpMethod;
 import io.parallec.core.resources.TcpUdpSshPingResourceStore;
 import io.parallec.core.task.ParallelTaskManager;
-
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.ning.http.client.AsyncHttpClient;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * 
@@ -170,7 +168,7 @@ public class ParallelClient {
             } catch (InterruptedException e) {
                 logger.error("error reinit httpClientStore", e);
             }
-            isClosed.set(true);
+            isClosed.set(false);
             logger.info("Parallel Client Resources has been reinitialized.");
         } else {
             logger.debug("NO OP. Resource was not released.");


### PR DESCRIPTION
Hello!
As I see `isClosed` is described as 'marked when all resources are released/not initialized.' but it is being set as true after re-init. Please look on and let me know if I'm correct on this.

Thanks.