### PR TITLE
Update initiation

### DIFF
--- a/src/main/java/io/parallec/core/ParallelClient.java
+++ b/src/main/java/io/parallec/core/ParallelClient.java
@@ -114,7 +114,6 @@ public class ParallelClient {
             ActorConfig.createAndGetActorSystem();
             httpClientStore.init();
             tcpSshPingResourceStore.init();
-            ParallelTaskManager.getInstance();
             isClosed.set(false);
             logger.info("Parallel Client Resources has been initialized.");
         } else {
@@ -139,8 +138,8 @@ public class ParallelClient {
             ActorConfig.shutDownActorSystemForce();
             httpClientStore.shutdown();
             tcpSshPingResourceStore.shutdown();
-            taskManager.cleanWaitTaskQueue();
-            taskManager.cleanInprogressJobMap();
+            cleanWaitTaskQueue();
+            cleanInprogressJobMap();
             isClosed.set(true);
             logger.info("Have released all ParallelClient resources "
                     + "(actor system + async+sync http client + task queue)"


### PR DESCRIPTION
- Remove getInstance because no parameter is receiving return value from this. Param `taskManager` is already getting instance when defined.
- Replace cleaning part to 'cleanInprogressJobMap' and 'cleanWaitTaskQueue'. It does same process, so it will be good to use same module when it needs to be modified.

Please look on and let me know if there is a problem.