### PR TITLE
Support adding encoding for the HTTP Post data

### DIFF
--- a/src/main/java/io/parallec/core/actor/HttpWorker.java
+++ b/src/main/java/io/parallec/core/actor/HttpWorker.java
@@ -179,6 +179,13 @@ public class HttpWorker extends UntypedActor {
             PcHttpUtils.addHeaders(builder, this.httpHeaderMap);
             if (!Strings.isNullOrEmpty(postData)) {
                 builder.setBody(postData);
+                String charset = "";
+                if (null!=this.httpHeaderMap) {
+                    charset = this.httpHeaderMap.get("charset");
+                }
+                if(!Strings.isNullOrEmpty(charset)) {
+                    builder.setBodyEncoding(charset);
+                }
             }
 
         } catch (Exception t) {


### PR DESCRIPTION
When I used the HTTP Post some Chinese characters, the server could only receive the "???" words, even I set the Http Headers with "charset=utf-8".

So I did that change to support adding the encoding for the post body if people set the headers with charset.

just like this:

pc.setHttpHeaders(new ParallecHeader()
                        .addPair("charset","utf-8"))